### PR TITLE
Allow for the appcompat library name to have an override

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     ktlint "com.pinterest:ktlint:0.33.0"
     compileOnly "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     //noinspection GradleCompatible
-    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '28.0.0')}"
+    implementation "${safeExtGet('coreLibName', 'com.android.support:appcompat-v7')}:${safeExtGet('supportLibVersion', '28.0.0')}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 


### PR DESCRIPTION
This is required for gradle-plugin-jetifier to work, or it picks an incompatible version while converting